### PR TITLE
fix remove namespace cream

### DIFF
--- a/l2/L2TriggerProcessor.cpp
+++ b/l2/L2TriggerProcessor.cpp
@@ -22,7 +22,6 @@ void L2TriggerProcessor::initialize(double _bypassProbability) {
 }
 
 uint_fast8_t L2TriggerProcessor::compute(Event* event) {
-	using namespace cream;
 
 //	const l0::MEPFragment* const L2Fragment =
 //			event->getL2Subevent()->getFragment(0);


### PR DESCRIPTION
Cream namespace doesn't exist anymore. Without this line the library is able to compile