### PR TITLE
L1 Data Packet

### DIFF
--- a/l1/CHODAlgo.h
+++ b/l1/CHODAlgo.h
@@ -39,12 +39,13 @@ public:
 	static uint_fast8_t processCHODTrigger(uint l0MaskID,
 			DecoderHandler& decoder, L1InfoToStorage* l1Info);
 	static void initialize(uint i, l1CHOD &l1ChodStruct);
-	static void writeData(L1Block &l1Block);
+	static void writeData(L1Algo* algoPacket, uint l0MaskID);
 
 	static bool isAlgoProcessed();
 	static void resetAlgoProcessed();
 	static bool isEmptyPacket();
 	static bool isBadData();
+	static void clear();
 
 private:
 

--- a/l1/KtagAlgo.h
+++ b/l1/KtagAlgo.h
@@ -31,7 +31,8 @@ public:
 	 *
 	 * @return uint_fast8_t <0> if the event is rejected, the L1 trigger type word in other cases.
 	 */
-	static uint_fast8_t processKtagTrigger(uint l0MaskID, DecoderHandler& decoder,L1InfoToStorage* l1Info);
+	static uint_fast8_t processKtagTrigger(uint l0MaskID,
+			DecoderHandler& decoder, L1InfoToStorage* l1Info);
 	/**
 	 * Calculates the sectorID based on the Tel62 and FPGA IDs. Possible results are between 0 and 7
 	 */
@@ -40,12 +41,13 @@ public:
 	}
 
 	static void initialize(uint i, l1KTAG &l1KtagStruct);
-	static void writeData(L1Block &l1Block);
+	static void writeData(L1Algo* algoPacket, uint l0MaskID);
 
 	static bool isAlgoProcessed();
 	static void resetAlgoProcessed();
 	static bool isEmptyPacket();
 	static bool isBadData();
+	static void clear();
 
 private:
 	static uint algoID; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
@@ -58,6 +60,8 @@ private:
 	static bool badData;
 	static bool isCHODRefTime;
 	static double averageCHODHitTime;
+	static uint nSectors_l0tp;
+	static uint nSectors_chod;
 
 };
 

--- a/l1/L1Fragment.h
+++ b/l1/L1Fragment.h
@@ -12,48 +12,51 @@
 namespace na62 {
 
 struct L1Global {
-	uint32_t PCfarmSoftwareID;
+//	uint32_t PCfarmSoftwareID;
+	uint8_t globalPacketLength; //length of global packet in bytes
 	uint8_t refFineTime;
-	uint8_t l0TriggerType :4;
-	uint8_t l0DataType :4;
-	uint16_t l0TriggerFlags;
-	uint8_t l1BypassProbability;
-	uint8_t l1FlagMode :4;
 	uint8_t refTimeSourceID :4; //not used yet
-	uint16_t l1AutoFlagFactor;
-	uint16_t l1ReductionFactor;
-	uint16_t l1DownscaleFactor;
+	uint8_t flagMode :4;
+	uint8_t format;
+	uint16_t downscaleFactor;
+	uint16_t reductionFactor;
+	uint8_t numberOfEnabledMasks;
+	uint8_t bypassProbability;
+	uint16_t autoFlagFactor;
 };
 
-struct L1Algo{
-	uint8_t l1AlgoID :4;
-	uint8_t l1AlgoProcessID :4;
-	uint8_t l1AlgoProcessed :2;
-	uint8_t reserved;
-	uint16_t l1AlgoDSFactor;
-	uint8_t l1AlgoOnlineTimeWindow;
-	uint8_t more_reserved;
+struct L1Algo {
+	uint8_t numberOfWords; //number of 32bit words in Algo packet, 2 header words are included
+	uint8_t processID;
+	uint8_t algoID;
+	uint8_t qualityFlags; //isEmptyPacket, isBadData, isProcessed
+	uint16_t downscaleFactor;
+	uint8_t onlineTimeWindow; //half width of online matching time window
+//	uint8_t l1AlgoProcessed :2;
+	uint8_t algoFlags; //enable, logic, flagging, downscale
+//	uint8_t more_reserved;
+	uint32_t l1Data[2];
+};
+
+struct L1Data {
+	uint32_t dataWords;
 };
 
 struct L1Mask {
+	uint8_t numberOfEnabledAlgos;
 	uint8_t triggerWord;
-	uint8_t numberOfEnabledAlgos :4;
-	uint8_t numberOfFlaggedAlgos :4;
-	uint8_t l1ReferenceFineTime;
-	uint8_t l1ReferenceTimeSourceID :4;
+	uint8_t maskID;
+	uint8_t flags;
 	uint16_t reductionFactor;
-	uint8_t algoEnableMask;
-	uint8_t algoLogicMask;
-	uint8_t algoFlagMask;
-	uint8_t algoDwScMask;
-	L1Algo l1Algo[4];
-	uint8_t maskID  :4;
-	uint32_t data  : 28;
+	uint8_t referenceFineTime;
+	uint8_t referenceTimeSourceID :4;
+	uint8_t reserved :4;
 };
 
 struct L1Block {
 	L1Global l1Global;
 	L1Mask l1Mask[16];
+	L1Algo l1Algo[16][16];
 };
 
 struct L1GLOBAL {
@@ -75,7 +78,5 @@ struct L1_BLOCK {
 };
 
 }
-
-
 
 #endif    /*  L1Fragment_H */

--- a/l1/L1TriggerProcessor.h
+++ b/l1/L1TriggerProcessor.h
@@ -67,7 +67,9 @@ public:
 	/**
 	 * Registers all reduction algorithms. Must be called before Options::Load is executed!
 	 */
-	static void writeData(L1Block &l1Block);
+	static void writeL1Data(Event* const event);
+	static void readL1Data(Event* const event);
+	static bool writeAlgoPacket(int algoID, L1Algo* algoPacket, uint l0MaskID);
 
 	/**
 	 * Placeholder for deciding whether or not to request ZS CREAM data
@@ -81,7 +83,7 @@ public:
 	static inline uint64_t GetL1InputStats() {
 		return L1InputEvents_;
 	}
-	static inline uint64_t GetL1InputReceivedStats() {
+	static inline uint64_t GetL1InputReducedStats() {
 		return L1InputReducedEvents_;
 	}
 	static inline uint64_t GetL1InputEventsPerBurst() {
@@ -102,7 +104,7 @@ public:
 	static inline uint GetL1AutoFlagFactor() {
 		return autoFlagFactor;
 	}
-	static inline uint GetNumberOfEnabledL0Masks() {
+	static inline uint_fast8_t GetNumberOfEnabledL0Masks() {
 		return numberOfEnabledL0Masks;
 	}
 	static inline uint GetL0MaskNumToMaskID(uint iNum) {
@@ -111,8 +113,21 @@ public:
 	static inline uint GetL0MaskIDToMaskNum(uint iMaskID) {
 		return MaskIDToNum[iMaskID];
 	}
+	static inline uint GetNumberOfEnabledAlgoPerMask(uint iMaskID) {
+		return numberOfEnabledAlgos[iMaskID];
+	}
+	static inline uint GetAlgoNumToAlgoID(uint iMaskID, uint iNum) {
+		return NumToAlgoID[iMaskID][iNum];
+	}
+	static inline uint GetAlgoIDToAlgoNum(uint iMaskID, uint iAlgoID) {
+		return AlgoIDToNum[iMaskID][iAlgoID];
+	}
+	static inline uint_fast32_t GetL1DataPacketSize() {
+		return L1DataPacketSize;
+	}
 
 	static void initialize(l1Struct &l1Struct);
+	static void clear();
 
 private:
 	static std::atomic<uint64_t>* L1Triggers_;
@@ -142,8 +157,8 @@ private:
 	static uint_fast16_t algoFlagMask[16];
 	static uint_fast16_t algoLogicMask[16];
 	static uint_fast16_t algoDwScMask[16];
-	static uint16_t algoDwScFactor[16][6]; //change the second dimension with the number of implemented algos
-	static uint8_t algoProcessID[16][6];
+	static uint16_t algoDwScFactor[16][10]; //change the second dimension with the number of implemented algos
+	static int algoProcessID[16][10];
 
 	static uint_fast16_t chodEnableMask;
 	static uint_fast16_t richEnableMask;
@@ -159,13 +174,6 @@ private:
 	static uint_fast16_t ircsacFlagMask;
 	static uint_fast16_t muvFlagMask;
 
-	static int chodProcessID[16];
-	static int richProcessID[16];
-	static int cedarProcessID[16];
-	static int lavProcessID[16];
-	static int ircsacProcessID[16];
-	static int muvProcessID[16];
-
 	// Downscaling variables
 	static uint chodAlgorithmId;
 	static uint richAlgorithmId;
@@ -179,6 +187,10 @@ private:
 	static uint_fast8_t l0DataType; //0x1 for physics, 0x2 for periodics, 0x4 for calibrations
 	static uint_fast16_t l0TrigFlags; //16 bit word: bit ith set to 0(1) if L0 mask ith has(has NOT) triggered!
 
+	static uint_fast8_t l1Trigger;
+	static uint_fast8_t l1GlobalFlagTrigger;
+	static uint_fast8_t l1MaskFlagTrigger;
+
 	static uint_fast8_t chodTrigger;
 	static uint_fast8_t richTrigger;
 	static uint_fast8_t cedarTrigger;
@@ -189,6 +201,8 @@ private:
 
 	static uint MaskIDToNum[16];
 	static uint NumToMaskID[16];
+	static uint AlgoIDToNum[16][10]; //change the second dimension with the number of implemented algos
+	static uint NumToAlgoID[16][10];
 
 	static L1InfoToStorage* l1Info_;
 	static uint l1ProcessID;
@@ -200,13 +214,14 @@ private:
 	static bool isAlgoEnableForAllL0Masks;
 	static bool isReducedEvent;
 	static bool isAllL1AlgoDisable;
+	static bool isL1WhileTimeout;
 	static uint_fast8_t evtRefFineTime;
 
 	static uint_fast8_t numberOfEnabledL0Masks;
 	static std::vector<int> l0MaskIDs;
 
-	static uint_fast32_t L1DataPacketLength;
-	static L1Block* l1Block;
+	static uint_fast32_t L1DataPacketSize;
+	static char * buffer;
 }
 ;
 

--- a/l1/LAVAlgo.cpp
+++ b/l1/LAVAlgo.cpp
@@ -203,18 +203,33 @@ bool LAVAlgo::isBadData() {
 	return badData;
 }
 
-void LAVAlgo::writeData(L1Block &l1Block) {
+void LAVAlgo::clear() {
+	algoProcessed = 0;
+	emptyPacket = 0;
+	badData = 0;
+}
 
-	int numToMaskID;
-	for (int iNum = 0; iNum < L1TriggerProcessor::GetNumberOfEnabledL0Masks(); iNum++) {
-		numToMaskID = L1TriggerProcessor::GetL0MaskNumToMaskID(iNum);
-		if (numToMaskID == -1)
-			LOG_ERROR("ERROR! Wrong association of mask ID!");
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoID = algoID;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoProcessed = algoProcessed;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoOnlineTimeWindow =
-				(uint) algoOnlineTimeWindow[numToMaskID];
-	}
+void LAVAlgo::writeData(L1Algo* algoPacket, uint l0MaskID) {
+
+	if (algoID != algoPacket->algoID)
+		LOG_ERROR(
+				"Algo ID does not match with Algo ID written within the packet!");
+	algoPacket->algoID = algoID;
+	algoPacket->onlineTimeWindow = (uint) algoOnlineTimeWindow[l0MaskID];
+	algoPacket->qualityFlags = (algoProcessed << 6) | (emptyPacket << 4)
+			| (badData << 2) | algoRefTimeSourceID[l0MaskID];
+	algoPacket->l1Data[0] = nHits;
+	if (algoRefTimeSourceID[l0MaskID] == 1)
+		algoPacket->l1Data[1] = averageCHODHitTime;
+	else
+		algoPacket->l1Data[1] = 0;
+	algoPacket->numberOfWords = (sizeof(L1Algo) / 4.);
+//	LOG_INFO("l0MaskID " << l0MaskID);
+//	LOG_INFO("algoID " << (uint)algoPacket->algoID);
+//	LOG_INFO("quality Flags " << (uint)algoPacket->qualityFlags);
+//	LOG_INFO("online TW " << (uint)algoPacket->onlineTimeWindow);
+//	LOG_INFO("Data Words " << algoPacket->l1Data[0] << " " << algoPacket->l1Data[1]);
+
 }
 
 }

--- a/l1/LAVAlgo.h
+++ b/l1/LAVAlgo.h
@@ -40,12 +40,13 @@ public:
 			DecoderHandler& decoder, L1InfoToStorage* l1Info);
 
 	static void initialize(uint i, l1LAV &l1LAVStruct);
-	static void writeData(L1Block &l1Block);
+	static void writeData(L1Algo* algoPacket, uint l0MaskID);
 
 	static bool isAlgoProcessed();
 	static void resetAlgoProcessed();
 	static bool isEmptyPacket();
 	static bool isBadData();
+	static void clear();
 
 private:
 

--- a/l1/MUVAlgo.cpp
+++ b/l1/MUVAlgo.cpp
@@ -364,19 +364,35 @@ bool MUV3Algo::isBadData() {
 	return badData;
 }
 
-void MUV3Algo::writeData(L1Block &l1Block) {
-
-	int numToMaskID;
-	for (int iNum = 0; iNum < L1TriggerProcessor::GetNumberOfEnabledL0Masks(); iNum++) {
-		numToMaskID = L1TriggerProcessor::GetL0MaskNumToMaskID(iNum);
-		if (numToMaskID == -1)
-			LOG_ERROR("ERROR! Wrong association of mask ID!");
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoID = algoID;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoProcessed = algoProcessed;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoOnlineTimeWindow =
-				(uint) algoOnlineTimeWindow[numToMaskID];
-	}
+void MUV3Algo::clear() {
+	algoProcessed = 0;
+	emptyPacket = 0;
+	badData = 0;
 }
+
+void MUV3Algo::writeData(L1Algo* algoPacket, uint l0MaskID) {
+
+	if (algoID != algoPacket->algoID)
+		LOG_ERROR(
+				"Algo ID does not match with Algo ID written within the packet!");
+	algoPacket->algoID = algoID;
+	algoPacket->onlineTimeWindow = (uint) algoOnlineTimeWindow[l0MaskID];
+	algoPacket->qualityFlags = (algoProcessed << 6) | (emptyPacket << 4)
+			| (badData << 2) | algoRefTimeSourceID[l0MaskID];
+	algoPacket->l1Data[0] = nTiles;
+	if (algoRefTimeSourceID[l0MaskID] == 1)
+		algoPacket->l1Data[1] = averageCHODHitTime;
+	else
+		algoPacket->l1Data[1] = 0;
+	algoPacket->numberOfWords = (sizeof(L1Algo) / 4.);
+//	LOG_INFO("l0MaskID " << l0MaskID);
+//	LOG_INFO("algoID " << (uint)algoPacket->algoID);
+//	LOG_INFO("quality Flags " << (uint)algoPacket->qualityFlags);
+//	LOG_INFO("online TW " << (uint)algoPacket->onlineTimeWindow);
+//	LOG_INFO("Data Words " << algoPacket->l1Data[0] << " " << algoPacket->l1Data[1]);
+
+}
+
 }
 /* namespace na62 */
 

--- a/l1/MUVAlgo.h
+++ b/l1/MUVAlgo.h
@@ -38,12 +38,13 @@ public:
 	static uint_fast8_t processMUV3Trigger2(uint l0MaskID, DecoderHandler& decoder,
 			L1InfoToStorage* l1Info);
 	static void initialize(uint i,l1MUV &l1MUV3Struct);
+	static void writeData(L1Algo* algoPacket, uint l0MaskID);
 
 	static bool isAlgoProcessed();
 	static void resetAlgoProcessed();
 	static bool isEmptyPacket();
 	static bool isBadData();
-	static void writeData(L1Block &l1Block);
+	static void clear();
 
 private:
 

--- a/l1/NewCHODAlgo.cpp
+++ b/l1/NewCHODAlgo.cpp
@@ -159,18 +159,34 @@ bool NewCHODAlgo::isBadData() {
 	return badData;
 }
 
-void NewCHODAlgo::writeData(L1Block &l1Block) {
-
-	int numToMaskID;
-	for (int iNum = 0; iNum < L1TriggerProcessor::GetNumberOfEnabledL0Masks(); iNum++) {
-		numToMaskID = L1TriggerProcessor::GetL0MaskNumToMaskID(iNum);
-		if (numToMaskID == -1)
-			LOG_ERROR("ERROR! Wrong association of mask ID!");
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoID = algoID;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoProcessed = algoProcessed;
-		(l1Block.l1Mask[iNum]).l1Algo[algoID].l1AlgoOnlineTimeWindow =
-				(uint) algoOnlineTimeWindow[numToMaskID];
-	}
+void NewCHODAlgo::clear() {
+	algoProcessed = 0;
+	emptyPacket = 0;
+	badData = 0;
 }
+
+void NewCHODAlgo::writeData(L1Algo* algoPacket, uint l0MaskID) {
+
+	if (algoID != algoPacket->algoID)
+		LOG_ERROR(
+				"Algo ID does not match with Algo ID written within the packet!");
+	algoPacket->algoID = algoID;
+	algoPacket->onlineTimeWindow = (uint) algoOnlineTimeWindow[l0MaskID];
+	algoPacket->qualityFlags = (algoProcessed << 6) | (emptyPacket << 4)
+			| (badData << 2) | algoRefTimeSourceID[l0MaskID];
+//	algoPacket->l1Data[0] = (uint) nHits_V + nHits_H;
+	if (averageHitTime != -1.0e+28)
+		algoPacket->l1Data[1] = averageHitTime;
+	else
+		algoPacket->l1Data[1] = 0;
+	algoPacket->numberOfWords = (sizeof(L1Algo) / 4.);
+//	LOG_INFO("l0MaskID " << l0MaskID);
+//	LOG_INFO("algoID " << (uint)algoPacket->algoID);
+//	LOG_INFO("quality Flags " << (uint)algoPacket->qualityFlags);
+//	LOG_INFO("online TW " << (uint)algoPacket->onlineTimeWindow);
+//	LOG_INFO("Data Words " << algoPacket->l1Data[0] << " " << algoPacket->l1Data[1]);
+
+}
+
 }
 /* namespace na62 */

--- a/l1/NewCHODAlgo.h
+++ b/l1/NewCHODAlgo.h
@@ -36,13 +36,14 @@ public:
 
 	static uint_fast8_t processNewCHODTrigger(uint l0MaskID, DecoderHandler& decoder, L1InfoToStorage* l1Info);
 //	static void initialize(uint i, l1NewCHOD &l1NewChodStruct);
-	static void writeData(L1Block &l1Block);
+	static void writeData(L1Algo* algoPacket, uint l0MaskID);
 
 	static bool isAlgoProcessed();
 	static void resetAlgoProcessed();
 	static bool isEmptyPacket();
 	static bool isBadData();
-//
+	static void clear();
+
 private:
 
 	static NewCHODParsConfFile* infoNewCHOD_;


### PR DESCRIPTION
 - CHOD trigger:	
        move averageHitTime reset, add clear method, modify writeData method
	write nHits and averageHitTime (if CHOD reference time)
 - KTAG trigger:
	add nSectors_l0tp and nSectors_chod as private variables of the class and move their initialization, add clear method, modify writeData method
	write nSectors and averageCHODHitTime (if CHOD reference time)
 - LAV trigger:
	add clear method, modify writeData method
	write nHits and averageCHODHitTime (if CHOD reference time)
 - MUV trigger:
	add clear method, modify writeData method
	write nTiles and averageCHODHitTime (if CHOD reference time)
 - NewCHOD trigger:
	add clear method, modify writeData method
	write averageHitTime (....)
 - L1Fragment:
	modify according to new data format
 - L1TriggerProcessor:
	add clear method and init of all variables storing trigger configuration parameters
	use of generic algoProcessID[nL0Masks][nL1Algos] instead of specific chod,...,muvProcessID
	increase dimension hosting number of algos
	add l1Trigger, l1GlobalFlagTrigger, l1MaskFlagTrigger, AlgoIDToNum[nL0Masks][nL1Algos], NumToAlgoID[nL0Masks][nL1Algos] as private variables of the class
	add isWhileTimeout flag
	remove usage and call to l1Block (to be removed completely from L1Fragment too!)
	move resetL1CHODProcessed
	modify writeData method so that it writes on a buffer of size initialised according to trigger configuration and then it copies the buffer on MEP(L1)
	add readData method for debugging
	add writeAlgoPacket method (only CHOD, KTAG, LAV, MUV3 are actually writing)
	add methods to get numberOfEnabledAlgosPerMask, NumToAlgoID, AlgoIDToNum, L1DataPacketSize