### PR TITLE
Use consistent naming convention for static data members (Capital beg…

### DIFF
--- a/l1/CHODAlgo.h
+++ b/l1/CHODAlgo.h
@@ -33,40 +33,20 @@ public:
 	 * @return uint_fast8_t <0> if the event is rejected, the L1 trigger type word in other cases.
 	 */
 
-	CHODAlgo();
-	~CHODAlgo();
-
 	static uint_fast8_t processCHODTrigger(uint l0MaskID,
 			DecoderHandler& decoder, L1InfoToStorage* l1Info);
 	static void initialize(uint i, l1CHOD &l1ChodStruct);
-	static void writeData(L1Algo* algoPacket, uint l0MaskID);
-
-	static bool isAlgoProcessed();
-	static void resetAlgoProcessed();
-	static bool isEmptyPacket();
-	static bool isBadData();
-	static void clear();
+	static void writeData(L1Algo* algoPacket, uint l0MaskID, L1InfoToStorage* l1Info);
 
 private:
 
-	static CHODParsConfFile* infoCHOD_;
-	static uint algoID; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
-	static uint algoLogic[16];
-	static uint algoRefTimeSourceID[16];
-	static double algoOnlineTimeWindow[16];
+	static CHODParsConfFile* InfoCHOD_;
+	static uint AlgoID_; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
+	static uint AlgoLogic_[16];
+	static uint AlgoRefTimeSourceID_[16];
+	static double AlgoOnlineTimeWindow_[16];
 
-	static bool algoProcessed;
-	static bool emptyPacket;
-	static bool badData;
-	static bool isCHODRefTime;
-
-	static int* slabGeo;
-	static uint nHits_V, nHits_H;
-	static uint nMaxSlabs;
-	static int slabID;
-//	static int quadrantID;
-	static int planeID;
-	static double averageHitTime;
+	static int* SlabGeo_;
 
 };
 

--- a/l1/KtagAlgo.h
+++ b/l1/KtagAlgo.h
@@ -41,27 +41,13 @@ public:
 	}
 
 	static void initialize(uint i, l1KTAG &l1KtagStruct);
-	static void writeData(L1Algo* algoPacket, uint l0MaskID);
-
-	static bool isAlgoProcessed();
-	static void resetAlgoProcessed();
-	static bool isEmptyPacket();
-	static bool isBadData();
-	static void clear();
+	static void writeData(L1Algo* algoPacket, uint l0MaskID, L1InfoToStorage* l1Info);
 
 private:
-	static uint algoID; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
-	static uint algoLogic[16];
-	static uint algoRefTimeSourceID[16];
-	static double algoOnlineTimeWindow[16];
-
-	static bool algoProcessed;
-	static bool emptyPacket;
-	static bool badData;
-	static bool isCHODRefTime;
-	static double averageCHODHitTime;
-	static uint nSectors_l0tp;
-	static uint nSectors_chod;
+	static uint AlgoID_; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
+	static uint AlgoLogic_[16];
+	static uint AlgoRefTimeSourceID_[16];
+	static double AlgoOnlineTimeWindow_[16];
 
 };
 

--- a/l1/L1InfoToStorage.cpp
+++ b/l1/L1InfoToStorage.cpp
@@ -17,12 +17,25 @@
 L1InfoToStorage* L1InfoToStorage::theInstance = nullptr;
 
 L1InfoToStorage::L1InfoToStorage() {
-	LOG_INFO("********************In L1 InfoToStorage");
+//	LOG_INFO("********************In L1 InfoToStorage");
 	chodTime = 0.;
-	L1CHODProcessed_ = false;
-	L1KTAGProcessed_ = false;
-	L1LAVProcessed_ = false;
-	L1MUV3Processed_ = false;
+	nKTAGSectors_l0tp = 0;
+	nKTAGSectors_chod = 0;
+	nCHODHits = 0;
+	nLAVHits = 0;
+	nMUV3Tiles = 0;
+	l1CHODProcessed_ = false;
+	l1CHODEmptyPacket_ = false;
+	l1CHODBadData_ = false;
+	l1KTAGProcessed_ = false;
+	l1KTAGEmptyPacket_ = false;
+	l1KTAGBadData_ = false;
+	l1LAVProcessed_ = false;
+	l1LAVEmptyPacket_ = false;
+	l1LAVBadData_ = false;
+	l1MUV3Processed_ = false;
+	l1MUV3EmptyPacket_ = false;
+	l1MUV3BadData_ = false;
 }
 
 L1InfoToStorage::~L1InfoToStorage() {
@@ -37,10 +50,50 @@ L1InfoToStorage* L1InfoToStorage::GetInstance() {
 
 }
 
-double L1InfoToStorage::getCHODAverageTime(){
+double L1InfoToStorage::getCHODAverageTime() {
 	return chodTime;
 }
 
-void L1InfoToStorage::setCHODAverageTime(double time){
+void L1InfoToStorage::setCHODAverageTime(double time) {
 	chodTime = time;
 }
+
+uint L1InfoToStorage::getL1CHODNHits() {
+	return nCHODHits;
+}
+
+void L1InfoToStorage::setL1CHODNHits(uint nHits) {
+	nCHODHits = nHits;
+}
+
+uint L1InfoToStorage::getL1KTAGNSectors_l0tp() {
+	return nKTAGSectors_l0tp;
+}
+
+void L1InfoToStorage::setL1KTAGNSectors_l0tp(uint nSectors) {
+	nKTAGSectors_l0tp = nSectors;
+}
+
+uint L1InfoToStorage::getL1KTAGNSectors_chod() {
+	return nKTAGSectors_chod;
+}
+
+void L1InfoToStorage::setL1KTAGNSectors_chod(uint nSectors) {
+	nKTAGSectors_chod = nSectors;
+}
+
+uint L1InfoToStorage::getL1LAVNHits() {
+	return nLAVHits;
+}
+void L1InfoToStorage::setL1LAVNHits(uint nHits) {
+	nLAVHits = nHits;
+}
+
+uint L1InfoToStorage::getL1MUV3NTiles() {
+	return nMUV3Tiles;
+}
+
+void L1InfoToStorage::setL1MUV3NTiles(uint nTiles) {
+	nMUV3Tiles = nTiles;
+}
+

--- a/l1/L1InfoToStorage.h
+++ b/l1/L1InfoToStorage.h
@@ -25,62 +25,159 @@ public:
 	double getCHODAverageTime();
 	void setCHODAverageTime(double time);
 
+	uint getL1CHODNHits();
+	void setL1CHODNHits(uint nHits);
+
+	uint getL1KTAGNSectors_l0tp();
+	void setL1KTAGNSectors_l0tp(uint nSectors);
+
+	uint getL1KTAGNSectors_chod();
+	void setL1KTAGNSectors_chod(uint nSectors);
+
+	uint getL1LAVNHits();
+	void setL1LAVNHits(uint nHits);
+
+	uint getL1MUV3NTiles();
+	void setL1MUV3NTiles(uint nTiles);
+
 	void setL1CHODProcessed() {
-		L1CHODProcessed_ = true;
+		l1CHODProcessed_ = true;
 	}
-
 	bool isL1CHODProcessed() const {
-		return L1CHODProcessed_;
+		return l1CHODProcessed_;
 	}
-
 	void resetL1CHODProcessed() {
-		L1CHODProcessed_ = false;
+		l1CHODProcessed_ = false;
+	}
+	void setL1CHODEmptyPacket() {
+		l1CHODEmptyPacket_ = true;
+	}
+	bool isL1CHODEmptyPacket() const {
+		return l1CHODEmptyPacket_;
+	}
+	void resetL1CHODEmptyPacket() {
+		l1CHODEmptyPacket_ = false;
+	}
+	void setL1CHODBadData() {
+		l1CHODBadData_ = true;
+	}
+	bool isL1CHODBadData() const {
+		return l1CHODBadData_;
+	}
+	void resetL1CHODBadData() {
+		l1CHODBadData_ = false;
 	}
 
 	void setL1KTAGProcessed() {
-		L1KTAGProcessed_ = true;
+		l1KTAGProcessed_ = true;
 	}
-
 	bool isL1KTAGProcessed() const {
-		return L1KTAGProcessed_;
+		return l1KTAGProcessed_;
 	}
-
 	void resetL1KTAGProcessed() {
-		L1KTAGProcessed_ = false;
+		l1KTAGProcessed_ = false;
+	}
+	void setL1KTAGEmptyPacket() {
+		l1KTAGEmptyPacket_ = true;
+	}
+	bool isL1KTAGEmptyPacket() const {
+		return l1KTAGEmptyPacket_;
+	}
+	void resetL1KTAGEmptyPacket() {
+		l1KTAGEmptyPacket_ = false;
+	}
+	void setL1KTAGBadData() {
+		l1KTAGBadData_ = true;
+	}
+	bool isL1KTAGBadData() const {
+		return l1KTAGBadData_;
+	}
+	void resetL1KTAGBadData() {
+		l1KTAGBadData_ = false;
 	}
 
 	void setL1LAVProcessed() {
-		L1LAVProcessed_ = true;
+		l1LAVProcessed_ = true;
 	}
-
 	bool isL1LAVProcessed() const {
-		return L1LAVProcessed_;
+		return l1LAVProcessed_;
 	}
-
 	void resetL1LAVProcessed() {
-		L1LAVProcessed_ = false;
+		l1LAVProcessed_ = false;
+	}
+	void setL1LAVEmptyPacket() {
+		l1LAVEmptyPacket_ = true;
+	}
+	bool isL1LAVEmptyPacket() const {
+		return l1LAVEmptyPacket_;
+	}
+	void resetL1LAVEmptyPacket() {
+		l1LAVEmptyPacket_ = false;
+	}
+	void setL1LAVBadData() {
+		l1LAVBadData_ = true;
+	}
+	bool isL1LAVBadData() const {
+		return l1LAVBadData_;
+	}
+	void resetL1LAVBadData() {
+		l1LAVBadData_ = false;
 	}
 
 	void setL1MUV3Processed() {
-		L1MUV3Processed_ = true;
+		l1MUV3Processed_ = true;
 	}
-
 	bool isL1MUV3Processed() const {
-		return L1MUV3Processed_;
+		return l1MUV3Processed_;
+	}
+	void resetL1MUV3Processed() {
+		l1MUV3Processed_ = false;
+	}
+	void setL1MUV3EmptyPacket() {
+		l1MUV3EmptyPacket_ = true;
+	}
+	bool isL1MUV3EmptyPacket() const {
+		return l1MUV3EmptyPacket_;
+	}
+	void resetL1MUV3EmptyPacket() {
+		l1MUV3EmptyPacket_ = false;
+	}
+	void setL1MUV3BadData() {
+		l1MUV3BadData_ = true;
+	}
+	bool isL1MUV3BadData() const {
+		return l1MUV3BadData_;
+	}
+	void resetL1MUV3BadData() {
+		l1MUV3BadData_ = false;
 	}
 
-	void resetL1MUV3Processed() {
-		L1MUV3Processed_ = false;
-	}
 private:
 
 	static L1InfoToStorage* theInstance;  // singleton instance
 
 	double chodTime;
-	bool L1CHODProcessed_;
-	bool L1KTAGProcessed_;
-	bool L1LAVProcessed_;
-	bool L1MUV3Processed_;
+
+	bool l1CHODProcessed_;
+	bool l1KTAGProcessed_;
+	bool l1LAVProcessed_;
+	bool l1MUV3Processed_;
+
+	bool l1CHODEmptyPacket_;
+	bool l1KTAGEmptyPacket_;
+	bool l1LAVEmptyPacket_;
+	bool l1MUV3EmptyPacket_;
+
+	bool l1CHODBadData_;
+	bool l1KTAGBadData_;
+	bool l1LAVBadData_;
+	bool l1MUV3BadData_;
+
+	uint nKTAGSectors_l0tp;
+	uint nKTAGSectors_chod;
+	uint nCHODHits;
+	uint nLAVHits;
+	uint nMUV3Tiles;
 
 };
 

--- a/l1/L1TriggerProcessor.cpp
+++ b/l1/L1TriggerProcessor.cpp
@@ -839,7 +839,7 @@ void L1TriggerProcessor::writeL1Data(Event* const event, const uint_fast8_t* l1T
 						| (((AlgoDwScMask_[numToMaskID] & (1 << numToAlgoID))
 								>> numToAlgoID));
 
-				writeAlgoPacket(numToAlgoID, algoPacket, numToMaskID);
+				L1TriggerProcessor::writeAlgoPacket(numToAlgoID, algoPacket, numToMaskID, l1Info);
 
 				refTimeSourceID_tmp = (algoPacket->qualityFlags & 0x3);
 				if (refTimeSourceID != refTimeSourceID_tmp)
@@ -877,19 +877,19 @@ void L1TriggerProcessor::writeL1Data(Event* const event, const uint_fast8_t* l1T
 }
 
 bool L1TriggerProcessor::writeAlgoPacket(int algoID, L1Algo* algoPacket,
-		uint l0MaskID) {
+		uint l0MaskID, L1InfoToStorage* l1Info) {
 	switch (algoID) {
 	case 0:
-		CHODAlgo::writeData(algoPacket, l0MaskID);
+		CHODAlgo::writeData(algoPacket, l0MaskID, l1Info);
 		return true;
 	case 1:
 //		RICHAlgo::writeData(algoPacket,l0MaskID);
 		return true;
 	case 2:
-		KtagAlgo::writeData(algoPacket, l0MaskID);
+		KtagAlgo::writeData(algoPacket, l0MaskID, l1Info);
 		return true;
 	case 3:
-		LAVAlgo::writeData(algoPacket, l0MaskID);
+		LAVAlgo::writeData(algoPacket, l0MaskID, l1Info);
 		return true;
 	case 4:
 //		IRCSACAlgo::writeData(algoPacket,l0MaskID);
@@ -898,7 +898,7 @@ bool L1TriggerProcessor::writeAlgoPacket(int algoID, L1Algo* algoPacket,
 //		StrawAlgo::writeData(algoPacket,l0MaskID);
 		return true;
 	case 6:
-		MUV3Algo::writeData(algoPacket, l0MaskID);
+		MUV3Algo::writeData(algoPacket, l0MaskID, l1Info);
 		return true;
 	case 7:
 //		NewCHODAlgo::writeData(algoPacket,l0MaskID);

--- a/l1/L1TriggerProcessor.h
+++ b/l1/L1TriggerProcessor.h
@@ -69,7 +69,7 @@ public:
 	 */
 	static void writeL1Data(Event* const event, const uint_fast8_t* l1TriggerWords, L1InfoToStorage* l1Info, bool isL1WhileTimeout=false);
 	static void readL1Data(Event* const event);
-	static bool writeAlgoPacket(int algoID, L1Algo* algoPacket, uint l0MaskID);
+	static bool writeAlgoPacket(int algoID, L1Algo* algoPacket, uint l0MaskID, L1InfoToStorage* l1Info);
 
 	/**
 	 * Placeholder for deciding whether or not to request ZS CREAM data

--- a/l1/LAVAlgo.h
+++ b/l1/LAVAlgo.h
@@ -33,38 +33,21 @@ public:
 	 * @return uint_fast8_t <0> if the event is rejected, the L1 trigger type word in other cases.
 	 */
 
-	LAVAlgo();
-	~LAVAlgo();
-
 	static uint_fast8_t processLAVTrigger(uint l0MaskID,
 			DecoderHandler& decoder, L1InfoToStorage* l1Info);
 
 	static void initialize(uint i, l1LAV &l1LAVStruct);
-	static void writeData(L1Algo* algoPacket, uint l0MaskID);
-
-	static bool isAlgoProcessed();
-	static void resetAlgoProcessed();
-	static bool isEmptyPacket();
-	static bool isBadData();
-	static void clear();
+	static void writeData(L1Algo* algoPacket, uint l0MaskID, L1InfoToStorage* l1Info);
 
 private:
 
-	static LAVParsConfFile* infoLAV_;
-	static uint algoID; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
-	static uint algoLogic[16];
-	static uint algoRefTimeSourceID[16];
-	static double algoOnlineTimeWindow[16];
+	static LAVParsConfFile* InfoLAV_;
+	static uint AlgoID_; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
+	static uint AlgoLogic_[16];
+	static uint AlgoRefTimeSourceID_[16];
+	static double AlgoOnlineTimeWindow_[16];
 
-	static bool algoProcessed;
-	static bool emptyPacket;
-	static bool badData;
-	static bool isCHODRefTime;
-
-	static int* lgGeo;
-	static int hit[maxNROchs];
-	static uint nHits;
-	static double averageCHODHitTime;
+	static int* LgGeo_;
 
 };
 

--- a/l1/MUVAlgo.h
+++ b/l1/MUVAlgo.h
@@ -29,8 +29,6 @@ public:
 	 * @return uint_fast8_t <0> if the event is rejected, the L1 trigger type word in other cases.
 	 */
 
-	MUV3Algo();
-	~MUV3Algo();
 	static uint_fast8_t processMUV3Trigger0(uint l0MaskID, DecoderHandler& decoder,
 			L1InfoToStorage* l1Info);
 	static uint_fast8_t processMUV3Trigger1(uint l0MaskID, DecoderHandler& decoder,
@@ -38,36 +36,17 @@ public:
 	static uint_fast8_t processMUV3Trigger2(uint l0MaskID, DecoderHandler& decoder,
 			L1InfoToStorage* l1Info);
 	static void initialize(uint i,l1MUV &l1MUV3Struct);
-	static void writeData(L1Algo* algoPacket, uint l0MaskID);
-
-	static bool isAlgoProcessed();
-	static void resetAlgoProcessed();
-	static bool isEmptyPacket();
-	static bool isBadData();
-	static void clear();
+	static void writeData(L1Algo* algoPacket, uint l0MaskID, L1InfoToStorage* l1Info);
 
 private:
 
-	static MUV3ParsConfFile* infoMUV3_;
-	static uint algoID; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
-	static uint algoLogic[16];
-	static uint algoRefTimeSourceID[16];
-	static double algoOnlineTimeWindow[16];
+	static MUV3ParsConfFile* InfoMUV3_;
+	static uint AlgoID_; //0 for CHOD, 1 for RICH, 2 for KTAG, 3 for LAV, 4 for IRCSAC, 5 for Straw, 6 for MUV3, 7 for NewCHOD
+	static uint AlgoLogic_[16];
+	static uint AlgoRefTimeSourceID_[16];
+	static double AlgoOnlineTimeWindow_[16];
 
-	static bool algoProcessed;
-	static bool emptyPacket;
-	static bool badData;
-	static bool isCHODRefTime;
-	static double averageCHODHitTime;
-
-	static int* pmtGeo;
-	static int roChID;
-	static uint pmtID1;
-	static uint pmtID2;
-
-	static bool tileID[152];
-	static uint pmtID[2];
-	static uint nTiles;
+	static int* PmtGeo_;
 
 };
 


### PR DESCRIPTION
…inning and _ at the end) in algortihms.

Extend writeAlgoPacket() method to get all parameters it needs.
Eliminate all static data members that were modified on a per event basis, except variables holding trigger configuration and channel map.
Add in L1infoStorage variables (algo specific) to write in data packet + methods to retrieve set/get them